### PR TITLE
adding in segment specific minimum lengths for filtering

### DIFF
--- a/phylogenetic/defaults/config.yaml
+++ b/phylogenetic/defaults/config.yaml
@@ -14,15 +14,10 @@ display_strain_field: "strain"
 
 filter:
   exclude: "defaults/exclude.txt"
-
-filter_L:
-  min_length: 3426
-
-filter_M:
-  min_length: 2192
-
-filter_S:
-  min_length: 700
+  min_length:
+    L: 3426
+    M: 2192
+    S: 700
 
 tree:
   method: "iqtree"

--- a/phylogenetic/defaults/config.yaml
+++ b/phylogenetic/defaults/config.yaml
@@ -13,8 +13,16 @@ strain_id_field: "accession"
 display_strain_field: "strain"
 
 filter:
-  min_length: 400
   exclude: "defaults/exclude.txt"
+
+filter_L:
+  min_length: 3426
+
+filter_M:
+  min_length: 2192
+
+filter_S:
+  min_length: 700
 
 tree:
   method: "iqtree"

--- a/phylogenetic/rules/prepare_sequences.smk
+++ b/phylogenetic/rules/prepare_sequences.smk
@@ -49,21 +49,21 @@ rule decompress:
         zstd -d -c {input.metadata} > {output.metadata}
         """
 
-rule filter_L:
+rule filter:
     """
     Filtering to
       - {params.sequences_per_group} sequence(s) per {params.group_by!s}
       - excluding strains in {input.exclude}
     """
     input:
-        sequences = "data/L/sequences.fasta",
-        metadata = "data/L/metadata.tsv",
+        sequences = "data/{segment}/sequences.fasta",
+        metadata = "data/{segment}/metadata.tsv",
         exclude = config['filter']['exclude']
     output:
-        sequences = "results/L/filtered.fasta"
+        sequences = "results/{segment}/filtered.fasta"
     params:
         strain_id_field = config["strain_id_field"],
-        min_length = config['filter_L']['min_length'],
+        min_length = lambda w: config['filter']['min_length'][w.segment],
         exclude = config['filter']['exclude']
     shell:
         """
@@ -76,59 +76,6 @@ rule filter_L:
             --exclude {input.exclude}
         """
 
-rule filter_M:
-    """
-    Filtering to
-      - {params.sequences_per_group} sequence(s) per {params.group_by!s}
-      - excluding strains in {input.exclude}
-    """
-    input:
-        sequences = "data/M/sequences.fasta",
-        metadata = "data/M/metadata.tsv",
-        exclude = config['filter']['exclude']
-    output:
-        sequences = "results/M/filtered.fasta"
-    params:
-        strain_id_field = config["strain_id_field"],
-        min_length = config['filter_M']['min_length'],
-        exclude = config['filter']['exclude']
-    shell:
-        """
-        augur filter \
-            --sequences {input.sequences} \
-            --metadata {input.metadata} \
-            --metadata-id-columns {params.strain_id_field} \
-            --output {output.sequences} \
-            --min-length {params.min_length} \
-            --exclude {input.exclude}
-        """
-
-rule filter_S:
-    """
-    Filtering to
-      - {params.sequences_per_group} sequence(s) per {params.group_by!s}
-      - excluding strains in {input.exclude}
-    """
-    input:
-        sequences = "data/S/sequences.fasta",
-        metadata = "data/S/metadata.tsv",
-        exclude = config['filter']['exclude']
-    output:
-        sequences = "results/S/filtered.fasta"
-    params:
-        strain_id_field = config["strain_id_field"],
-        min_length = config['filter_S']['min_length'],
-        exclude = config['filter']['exclude']
-    shell:
-        """
-        augur filter \
-            --sequences {input.sequences} \
-            --metadata {input.metadata} \
-            --metadata-id-columns {params.strain_id_field} \
-            --output {output.sequences} \
-            --min-length {params.min_length} \
-            --exclude {input.exclude}
-        """
 
 rule align:
     """

--- a/phylogenetic/rules/prepare_sequences.smk
+++ b/phylogenetic/rules/prepare_sequences.smk
@@ -49,21 +49,75 @@ rule decompress:
         zstd -d -c {input.metadata} > {output.metadata}
         """
 
-rule filter:
+rule filter_L:
     """
     Filtering to
       - {params.sequences_per_group} sequence(s) per {params.group_by!s}
       - excluding strains in {input.exclude}
     """
     input:
-        sequences = "data/{segment}/sequences.fasta",
-        metadata = "data/{segment}/metadata.tsv",
+        sequences = "data/L/sequences.fasta",
+        metadata = "data/L/metadata.tsv",
         exclude = config['filter']['exclude']
     output:
-        sequences = "results/{segment}/filtered.fasta"
+        sequences = "results/L/filtered.fasta"
     params:
         strain_id_field = config["strain_id_field"],
-        min_length = config['filter']['min_length'],
+        min_length = config['filter_L']['min_length'],
+        exclude = config['filter']['exclude']
+    shell:
+        """
+        augur filter \
+            --sequences {input.sequences} \
+            --metadata {input.metadata} \
+            --metadata-id-columns {params.strain_id_field} \
+            --output {output.sequences} \
+            --min-length {params.min_length} \
+            --exclude {input.exclude}
+        """
+
+rule filter_M:
+    """
+    Filtering to
+      - {params.sequences_per_group} sequence(s) per {params.group_by!s}
+      - excluding strains in {input.exclude}
+    """
+    input:
+        sequences = "data/M/sequences.fasta",
+        metadata = "data/M/metadata.tsv",
+        exclude = config['filter']['exclude']
+    output:
+        sequences = "results/M/filtered.fasta"
+    params:
+        strain_id_field = config["strain_id_field"],
+        min_length = config['filter_M']['min_length'],
+        exclude = config['filter']['exclude']
+    shell:
+        """
+        augur filter \
+            --sequences {input.sequences} \
+            --metadata {input.metadata} \
+            --metadata-id-columns {params.strain_id_field} \
+            --output {output.sequences} \
+            --min-length {params.min_length} \
+            --exclude {input.exclude}
+        """
+
+rule filter_S:
+    """
+    Filtering to
+      - {params.sequences_per_group} sequence(s) per {params.group_by!s}
+      - excluding strains in {input.exclude}
+    """
+    input:
+        sequences = "data/S/sequences.fasta",
+        metadata = "data/S/metadata.tsv",
+        exclude = config['filter']['exclude']
+    output:
+        sequences = "results/S/filtered.fasta"
+    params:
+        strain_id_field = config["strain_id_field"],
+        min_length = config['filter_S']['min_length'],
         exclude = config['filter']['exclude']
     shell:
         """


### PR DESCRIPTION
This is response to issue #4 which requires specific minimum lengths for each separate oropouche segment. 

This is done by adding in separate filtering steps for each segment and having a separate `filter_{segment}` flag in the `config` file. 

I'm going to tag @joverlee521 here because I'm not sure if there's a standardized way of doing this that's not my kinda hacky solution 

These new trees are up on staging:
https://nextstrain.org/staging/oropouche/L
https://nextstrain.org/staging/oropouche/M
https://nextstrain.org/staging/oropouche/S
