### PR TITLE
Exclude strain BeH505764

### DIFF
--- a/phylogenetic/defaults/exclude.txt
+++ b/phylogenetic/defaults/exclude.txt
@@ -1,20 +1,24 @@
-AY993909    #duplicated
-AY993910    #duplicated
-AY993911    #duplicated
-AF164532    #duplicated
-AY993909    #duplicated
-AY993910    #duplicated
-AY993911    #duplicated
-AY117135    #duplicated
-HM470140    #duplicated
-AY704563    #duplicated
-AY704568    #duplicated
-AY704566    #duplicated
-PP952117    #duplicated
-EF467371    #duplicated
-EF467372    #duplicated
-EF467370    #   duplicated
-EF467369    #   duplicated
-AF164531    #   duplicated
-NC_005775   #   duplicated
-AF441119    #   duplicated
+AY993909    # duplicated
+AY993910    # duplicated
+AY993911    # duplicated
+AF164532    # duplicated
+AY993909    # duplicated
+AY993910    # duplicated
+AY993911    # duplicated
+AY117135    # duplicated
+HM470140    # duplicated
+AY704563    # duplicated
+AY704568    # duplicated
+AY704566    # duplicated
+PP952117    # duplicated
+EF467371    # duplicated
+EF467372    # duplicated
+EF467370    # duplicated
+EF467369    # duplicated
+AF164531    # duplicated
+NC_005775   # duplicated
+AF441119    # duplicated
+
+PP357049    # strain BeH505764, M segment, fall extremely basal in the tree, far outside clock expectation
+PP357048    # strain BeH505764, L segment, looks normal but excluding because of issue with M
+PP357050    # strain BeH505764, S segment, looks normal but excluding because of issue with M


### PR DESCRIPTION
The M segment for strain BeH505764 (accession PP357049) was grouping near the vary base of the tree and this was screwing up the ability to have a reliable clock. In general you want a divergence tree that looks appropriately ultrametric, ie tips fall where you'd expect them to.

Excluding this sequence, largely resolves the issue with the root-to-tip regression of segment M. I chose to exclude strain BeH505764 for segments L and S for good measure.

Here's the resulting M tree with BeH505764 excluded: https://nextstrain.org/staging/oropouche/M/exclude-BeH505764

Before excluding, the R^2 was 0.005 (https://nextstrain.org/staging/oropouche/M?branches=hide&l=scatter&regression=show&scatterY=div). After excluding, the R^2 is 0.79 (https://next.nextstrain.org/staging/oropouche/M/exclude-BeH505764?branches=hide&l=scatter&regression=show&scatterY=div).

Resolves #10