### PR TITLE
adding in description.md file 

### DIFF
--- a/phylogenetic/defaults/color_orderings.tsv
+++ b/phylogenetic/defaults/color_orderings.tsv
@@ -235,15 +235,9 @@ recency	New
 ################
 
 host	Homo sapiens
-host	Canis lupus familiaris
-host	Capra hircus
-host	Cavia porcellus
-host	Rodentia
-host	Mus baoulei
-host	Rattus norvegicus
-host	Hylomyscus pamfi
-host	Lophuromys sikapusi
-host	Mastomys sp.
-host	Mastomys
-host	Mastomys erythroleucus
-host	Mastomys natalensis
+host	Culicoides paraensis
+host	Bradypus tridactylus
+host	Culex quinquefasciatus
+host	Ochlerotatus serratus
+host	Callithrix sp.
+

--- a/phylogenetic/defaults/config.yaml
+++ b/phylogenetic/defaults/config.yaml
@@ -25,7 +25,7 @@ tree:
 refine:
   coalescent: "opt"
   date_inference: "marginal"
-  clock_rate: 0.0012
+  clock_rate: 0.0014
 
 ancestral:
   inference: "joint"
@@ -35,4 +35,4 @@ traits:
 
 export:
   auspice_config: "defaults/auspice_config.json"
-  # description: "defaults/description.md"
+  description: "defaults/description.md"

--- a/phylogenetic/defaults/description.md
+++ b/phylogenetic/defaults/description.md
@@ -4,7 +4,7 @@ Please note that although data generators have generously shared data in an open
 
 Much of the recent genomic data here comes from the publication [Naveca et al 2024](https://doi.org/10.1101/2024.07.23.24310415) but more recent sequences from NCBI may not yet be published.
 
-We maintain three views of Oropouche virus evolution: one showing evolution of the [L segment](https://nextstrain.org/oropouche/L), one for the [M segment](https://nextstrain.org/oropouche/M),and the other showing evolution of the [S segment](https://nextstrain.org/oropouche/S). A tangle tree showing [co-evolution of L and M](https://nextstrain.org/oropouche/L:oropouche/M) is also available.
+<!-- We maintain three views of Oropouche virus evolution: one showing evolution of the [L segment](https://nextstrain.org/oropouche/L), one for the [M segment](https://nextstrain.org/oropouche/M),and the other showing evolution of the [S segment](https://nextstrain.org/oropouche/S). A tangle tree showing [co-evolution of L and M](https://nextstrain.org/oropouche/L:oropouche/M) is also available.
 
 #### Underlying data
 
@@ -21,7 +21,7 @@ We curate sequence data and metadata from NCBI as the starting point for our ana
 ##### S segment
 * [data.nextstrain.org/files/workflows/oropouche/S/sequences.fasta.zst](https://data.nextstrain.org/files/workflows/oropouche/S/sequences.fasta.zst)
 * [data.nextstrain.org/files/workflows/oropouche/S/metadata.tsv.zst](https://data.nextstrain.org/files/workflows/oropouche/S/metadata.tsv.zst)
-
+ -->
 
 ---
 

--- a/phylogenetic/defaults/description.md
+++ b/phylogenetic/defaults/description.md
@@ -1,0 +1,28 @@
+We gratefully acknowledge the authors, originating and submitting laboratories of the genetic sequences and metadata for sharing their work.
+
+Please note that although data generators have generously shared data in an open fashion, that does not mean there should be free license to publish on this data. Data generators should be cited where possible and collaborations should be sought in some circumstances. Please try to avoid scooping someone else's work. Reach out if uncertain.
+
+Much of the recent genomic data here comes from the publication [Naveca et al 2024](https://doi.org/10.1101/2024.07.23.24310415) but more recent sequences from NCBI may not yet be published.
+
+We maintain three views of Oropouche virus evolution: one showing evolution of the [L segment](https://nextstrain.org/oropouche/L), one for the [M segment](https://nextstrain.org/oropouche/M),and the other showing evolution of the [S segment](https://nextstrain.org/oropouche/S). A tangle tree showing [co-evolution of L and M](https://nextstrain.org/oropouche/L:oropouche/M) is also available.
+
+#### Underlying data
+
+We curate sequence data and metadata from NCBI as the starting point for our analyses. Curated sequences and metadata are available as flat files at:
+
+##### L segment
+* [data.nextstrain.org/files/workflows/oropouche/L/sequences.fasta.zst](https://data.nextstrain.org/files/workflows/oropouche/L/sequences.fasta.zst)
+* [data.nextstrain.org/files/workflows/oropouche/L/metadata.tsv.zst](https://data.nextstrain.org/files/workflows/oropouche/L/metadata.tsv.zst)
+
+##### M segment
+* [data.nextstrain.org/files/workflows/oropouche/M/sequences.fasta.zst](https://data.nextstrain.org/files/workflows/oropouche/M/sequences.fasta.zst)
+* [data.nextstrain.org/files/workflows/oropouche/M/metadata.tsv.zst](https://data.nextstrain.org/files/workflows/oropouche/M/metadata.tsv.zst)
+
+##### S segment
+* [data.nextstrain.org/files/workflows/oropouche/S/sequences.fasta.zst](https://data.nextstrain.org/files/workflows/oropouche/S/sequences.fasta.zst)
+* [data.nextstrain.org/files/workflows/oropouche/S/metadata.tsv.zst](https://data.nextstrain.org/files/workflows/oropouche/S/metadata.tsv.zst)
+
+
+---
+
+Screenshots may be used under a [CC-BY-4.0 license](https://creativecommons.org/licenses/by/4.0/) and attribution to nextstrain.org must be provided.

--- a/phylogenetic/rules/export.smk
+++ b/phylogenetic/rules/export.smk
@@ -50,7 +50,7 @@ rule export:
         nt_muts = "results/{segment}/nt_muts.json",
         aa_muts = "results/{segment}/aa_muts.json",
         colors = "results/{segment}/colors.tsv",
-        # description = config['export']['description'],
+        description = config['export']['description'],
         auspice_config = config['export']['auspice_config'],
     output:
         auspice ="results/{segment}/oropouche.json",
@@ -63,6 +63,7 @@ rule export:
             --metadata {input.metadata} \
             --metadata-id-columns {params.strain_id_field} \
             --node-data {input.branch_lengths} {input.traits} {input.nt_muts} {input.aa_muts} \
+            --description {input.description} \
             --colors {input.colors} \
             --auspice-config {input.auspice_config} \
             --output {output.auspice} \


### PR DESCRIPTION
Just adding in the description.md file with future, currently non-existent links to the flat files for when it goes live on nextstrain.org. The main sequence generators are Silvia et al and Almeida et al, but it seems like they were all submitted as part of https://www.medrxiv.org/content/10.1101/2024.08.02.24311415v2.full-text so I just went ahead and cited the preprint as Naveca et al., (especially since both Silvia and Almeida are co-authors on the paper). 

Not sure if this is the correct convention so I'd appreciate a second opinion @genehack 

The resulting trees can be found on : 
- https://nextstrain.org/staging/oropouche/L 
- https://nextstrain.org/staging/oropouche/M
- https://nextstrain.org/staging/oropouche/S