### PR TITLE
ingest: Add retries to `entrez_via_accessions`

### DIFF
--- a/ingest/rules/fetch_from_ncbi.smk
+++ b/ingest/rules/fetch_from_ncbi.smk
@@ -141,6 +141,8 @@ rule entrez_via_accessions:
         metadata="data/metadata_curated.tsv",
     output:
         genbank="data/genbank.gb",
+    # Allow retries in case of network errors
+    retries: 5
     benchmark:
         "benchmarks/entrez_via_accessions.txt"
     shell:


### PR DESCRIPTION
## Description of proposed changes

Today's automated run failed the first time due to a network issue during fetch from Entrez,¹ but the manual re-run of the workflow completed without any issues.²

Adding the Snakemake `retries` directive to `entrez_via_accessions` to automatically retry the job in case of similar network errors in the future. I chose 5 retries to match the `fetch_ncbi_dataset_package` rule.

¹ <https://github.com/nextstrain/oropouche/actions/runs/11688970008/job/32550688185#step:13:401> 
² <https://github.com/nextstrain/oropouche/actions/runs/11688970008>

<!-- What is the goal of this pull request? What does this pull request change? -->


## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
